### PR TITLE
Prevented user enumeration by reducing timing variation.

### DIFF
--- a/django-dual-authentication/backends.py
+++ b/django-dual-authentication/backends.py
@@ -67,6 +67,9 @@ class DualAuthentication(ModelBackend):
                 if user.check_password(password):
                     return user
             except:
+                # Run the default password hasher once to reduce the timing
+                # difference between an existing and a non-existing user.
+                UserModel().set_password(password)
                 return None
 
     def get_user(self, username):


### PR DESCRIPTION
Like Django itself prior to 1.7, this backend can reveal whether or not a username/e-mail address exist in the database, from the timing of the login form. If the user exists, the login form checks the password, which involves running the (intentionally slow) hasher. This difference is so large that even the most naive timing attacks can detect this.

The simple solution to this is to also run the hasher when no user was found. See the Django ticket for more background: https://code.djangoproject.com/ticket/20760

The Django commit also has a suggestion for how to test this, which I've not included in this PR: https://github.com/django/django/commit/5dbca13f3baa2e1bafd77e84a80ad6d8a074712e#diff-1
